### PR TITLE
task(CVE-2017-18214): RHMAP-20718 - Upgrade moment dependency

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SnapScreen",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "haversine": "^1.0.2",
     "jwt-decode": "^2.2.0",
-    "moment": "^2.18.1",
+    "moment": "2.22.2",
     "native-base": "2.1.2",
     "react": "16.0.0-alpha.6",
     "react-native": "0.43.4",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2634,9 +2634,9 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-moment@2.x.x, moment@^2.18.1:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
+moment@2.x.x, moment@^2.19.3:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.3.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 
 morgan@~1.6.1:
   version "1.6.1"


### PR DESCRIPTION
# Jira:
https://issues.jboss.org/browse/RHMAP-20718

# What
* Upgrade moment dependency from `^2.18.1` to `2.22.2` used to manipulate dates
* It is not a break change/update. See the moment [Changelog](https://github.com/moment/moment/blob/develop/CHANGELOG.md)
* Remove sonar file since it is not so long used.

# Why
Solve vulnerability. For further information check: https://nvd.nist.gov/vuln/detail/CVE-2017-18214

# How
Update the dep for the latest one which doesn't have break changes. 

# Verification Steps
* Run the app locally. See https://github.com/feedhenry/snapscreen/blob/master/client/README.md

````
cmacedo@camilas-MBP ~/fh-templates/snapscreen/client (RHMAP-20718) $ react-native start
Scanning 634 folders for symlinks in /Users/cmacedo/fh-templates/snapscreen/client/node_modules (9ms)
 ┌────────────────────────────────────────────────────────────────────────────┐ 
 │  Running packager on port 8081.                                            │ 
 │                                                                            │ 
 │  Keep this packager running while developing on any JS projects. Feel      │ 
 │  free to close this tab and run your own packager instance if you          │ 
 │  prefer.                                                                   │ 
 │                                                                            │ 
 │  https://github.com/facebook/react-native                                  │ 
 │                                                                            │ 
 └────────────────────────────────────────────────────────────────────────────┘ 
Looking for JS files in
   /Users/cmacedo/fh-templates/snapscreen/client 

Loading dependency graph...
React packager ready.

Loading dependency graph, done.
````

<img width="345" alt="screen shot 2018-06-12 at 15 41 37" src="https://user-images.githubusercontent.com/7708031/41297491-243e5d86-6e57-11e8-97f9-b220b9f6f30e.png">
